### PR TITLE
Add VolumeGroup datastore parsing and fix invalid enum constants in nutanix_volumes gem

### DIFF
--- a/app/models/manageiq/providers/nutanix/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/nutanix/inventory/parser/infra_manager.rb
@@ -116,20 +116,25 @@ class ManageIQ::Providers::Nutanix::Inventory::Parser::InfraManager < ManageIQ::
 
   def parse_datastores
     collector.datastores.each do |ds|
-      name        = ds.name rescue "unknown"
-      ems_ref     = ds.ext_id || ds.uuid rescue nil
-      total_space = ds.resources&.map(&:size_bytes)&.sum rescue nil
-      free_space  = nil  # Nutanix Volume Groups may not expose this directly
+      name        = ds.try(:target_name) || ds.try(:name) || "unknown"
+      ems_ref     = ds.try(:ext_id)
+      total_space = nil  # You can update this if you later find a way to calculate size
+      free_space  = nil  # Nutanix Volumes API doesn't provide this directly
+
+      next if ems_ref.nil?
 
       persister.storages.build(
         :name        => name,
-        :store_type  => 'NutanixVolume',
+        :store_type  => 'NutanixVolumeGroup',
         :total_space => total_space,
         :free_space  => free_space,
-        :ems_ref     => ems_ref
+        :ems_ref     => ems_ref,
+        :location    => "VolumeGroup:#{name}",
+        :ems_id      => persister.manager.id
       )
     end
   end
+
 
   def parse_templates
     collector.templates.each do |template|


### PR DESCRIPTION
**Summary**

This PR adds support for collecting VolumeGroup datastore inventory from the Nutanix Volumes API and includes a workaround to address a known issue in the nutanix_volumes SDK gem.

**Changes**

Implemented parse_datastores in Inventory::Parser::InfraManager to process Nutanix VolumeGroup inventory objects.
Fixed enum constant naming bug by removing leading underscores from _UNKNOWN and _REDACTED to prevent runtime errors when accessing enum values.

**SDK Bug Workaround**

The nutanix_volumes gem (v0.1.0) currently generates constants with invalid Ruby identifiers such as _UNKNOWN and _REDACTED, which cause runtime errors when accessing enum values.
To temporarily fix this, the following command was used to rewrite all instances of these constants to valid Ruby format:

**Run in root of your project directory (adjust path as needed)**

find /home/ubuntu/.rbenv/versions/3.3.7/lib/ruby/gems/3.3.0/gems/nutanix_volumes-0.1.0 \
  -type f -name "*.rb" \
  -exec sed -i 's/\b_UNKNOWN\b/UNKNOWN/g; s/\b_REDACTED\b/REDACTED/g' {} +
