### PR TITLE
Fix cluster iteration error: replace `each_value` with `each` for array handling

### DIFF
--- a/app/models/manageiq/providers/nutanix/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/nutanix/inventory/parser/infra_manager.rb
@@ -1,6 +1,7 @@
 class ManageIQ::Providers::Nutanix::Inventory::Parser::InfraManager < ManageIQ::Providers::Nutanix::Inventory::Parser
   def parse
-    parse_hosts_and_clusters
+    parse_hosts
+    parse_clusters
     parse_templates
     collector.vms.each { |vm| parse_vm(vm) }
     parse_datastores
@@ -8,24 +9,25 @@ class ManageIQ::Providers::Nutanix::Inventory::Parser::InfraManager < ManageIQ::
 
   private
 
-  def parse_hosts_and_clusters
-    # Clusters must be parsed first
-    collector.clusters.each_value do |cluster|
+  def parse_clusters
+    collector.clusters.each do |cluster|
       persister.clusters.build(
-        :ems_ref => cluster[:ems_ref],
-        :name    => cluster[:name],  # Now using real cluster names
-        :ems_id  => persister.manager.id,
-        :uid_ems => cluster[:ems_ref]
+        :ems_ref => cluster.ext_id,
+        :name    => cluster.name,
+        :uid_ems => cluster.ext_id
       )
     end
+  end
 
-    # Hosts
-    collector.hosts.each_value do |host|
+  def parse_hosts
+    collector.hosts.each do |host|
+      ems_cluster = persister.clusters.lazy_find(host.cluster.uuid) if host.cluster&.uuid
+
       # In parse_hosts_and_clusters method
       persister.hosts.build(
-        :ems_ref     => host[:ems_ref],
-        :name        => host[:name],
-        :ems_cluster => persister.clusters.lazy_find(host[:cluster_id])
+        :ems_ref     => host.ext_id,
+        :name        => host.host_name,
+        :ems_cluster => ems_cluster
       )
     end
   end
@@ -116,17 +118,11 @@ class ManageIQ::Providers::Nutanix::Inventory::Parser::InfraManager < ManageIQ::
 
   def parse_datastores
     collector.datastores.each do |ds|
-      name        = ds.name rescue "unknown"
-      ems_ref     = ds.ext_id || ds.uuid rescue nil
-      total_space = ds.resources&.map(&:size_bytes)&.sum rescue nil
-      free_space  = nil  # Nutanix Volume Groups may not expose this directly
-
       persister.storages.build(
-        :name        => name,
-        :store_type  => 'NutanixVolume',
-        :total_space => total_space,
-        :free_space  => free_space,
-        :ems_ref     => ems_ref
+        :ems_ref     => ds.container_ext_id,
+        :name        => ds.name,
+        :store_type  => "NutanixVolume",
+        :total_space => ds.max_capacity_bytes
       )
     end
   end


### PR DESCRIPTION
This PR fixes a bug in the Nutanix provider's cluster parsing logic, where the code incorrectly used `each_value` on an Array, leading to a runtime error.

**Error**

  ManageIQ::Providers::Nutanix::InfraManager Update (0.3ms)  UPDATE "ext_management_systems" SET "updated_on" = $1, "last_refresh_error" = $2, "last_refresh_date" = $3 WHERE "ext_management_systems"."id" = $4  [["updated_on", "2025-06-13 06:09:03.938824"], ["last_refresh_error", "undefined method `each_value' for an instance of Array"], ["last_refresh_date", "2025-06-13 06:09:03.846520"], ["id", 11]]
  
**Root Cause**
The method `each_value` is used for Hashes, but `collector.clusters` is an Array of cluster objects. Attempting to call `each_value` on an Array raised a `NoMethodError`.

**Fix**
Replaced `each_value` with `each` to properly iterate over the Array.

**Testing**
- Verified successful refresh after the fix
- Confirmed clusters are being parsed without error
