### PR TITLE
Fix vm details page mac_addresses method

### DIFF
--- a/app/models/manageiq/providers/nutanix/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/nutanix/infra_manager/vm.rb
@@ -27,7 +27,7 @@ class ManageIQ::Providers::Nutanix::InfraManager::Vm < ManageIQ::Providers::Infr
 
   # Add custom methods for UI display
   def mac_addresses
-    hardware.nics.map(&:mac_address).compact
+    hardware.nics.map(&:address).compact
   end
 
   def ip_addresses


### PR DESCRIPTION
The correct attribute for GuestDevice is address not mac_address

Fixes 
<img width="1187" height="638" alt="image" src="https://github.com/user-attachments/assets/7c605a88-c97c-4131-9d64-489d986a44e6" />

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
