### PR TITLE
Lock down to nutanix_* < v0.2.0

### DIFF
--- a/manageiq-providers-nutanix.gemspec
+++ b/manageiq-providers-nutanix.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "simplecov",  ">= 0.21.2"
 
-  spec.add_dependency "nutanix_clustermgmt", "~> 0.1"
-  spec.add_dependency "nutanix_vmm",         "~> 0.1"
-  spec.add_dependency "nutanix_volumes",     "~> 0.1"
+  spec.add_dependency "nutanix_clustermgmt", "~> 0.1.0"
+  spec.add_dependency "nutanix_vmm",         "~> 0.1.0"
+  spec.add_dependency "nutanix_volumes",     "~> 0.1.0"
 end


### PR DESCRIPTION
The updates to the nutanix SDK include new required API parameters which are not included in our VCR cassettes.  The current code will work fine against a live provider but newer code with older API responses will not.

Ref: https://github.com/ManageIQ/manageiq/pull/23674#issuecomment-3633025527

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
