### PR TITLE
[SPASSKY] Drop Ruby 3.1 from spassky

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,6 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-        - '3.1'
         - '3.3'
     services:
       postgres:


### PR DESCRIPTION
@agrare Please review. Somehow we missed this when we blasted it out (probably a timing thing).